### PR TITLE
Added dependabot yaml file.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
Added a `dependabot.yml` file to try to unpause dependabot for this repo. According to the [documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates#about-automatic-deactivation-of-dependabot-updates):

> An active repository is a repository for which a user (not Dependabot) has carried out any of the actions below in the last 90 days:
> * Merge or close a Dependabot pull request on the repository.
> * Make a change to the dependabot.yml file for the repository.
> * Manually trigger a security update or a version update.
> * Enable Dependabot security updates for the repository.
> * Use @dependabot commands on pull requests.