### PR TITLE
Handling filter calls

### DIFF
--- a/src/clientFactory.ts
+++ b/src/clientFactory.ts
@@ -369,19 +369,25 @@ export async function buildClient(opts: ClientFactoryOptions): Promise<Client> {
         return;
       }
 
-      let responseBody = await r.json();
-
-      logger('debug', 'Received the following response from the Adzerk API', {
-        status: r.status,
-        body: responseBody,
-      });
-
-
       if (![200, 201].includes(r.status)) {
+        const responseBody =  await r.json();
+        
+        logger('debug', 'Received the following response from the Adzerk API', {
+          status: r.status,
+          body: responseBody,
+        });
+
         throw responseBody;
       }
 
       if (op !== 'filter') {
+        let responseBody = await r.json();
+
+        logger('debug', 'Received the following response from the Adzerk API', {
+          status: r.status,
+          body: responseBody,
+        });
+      
         return convertKeysToCamelcase(responseBody);
       }
 


### PR DESCRIPTION
When doing a `filter` operation the body of the response back from the kevel api is read twice. Once when its converted into a json https://github.com/adzerk/adzerk-management-sdk-js/blob/master/src/clientFactory.ts#L372 and another time when its being converted from the jsonld format returned by the api https://github.com/adzerk/adzerk-management-sdk-js/blob/master/src/clientFactory.ts#L392.

Because its already been read once the underlying stream is already at the end and therefore the r.body call when calling `handleResponseStream` returns nothing and we don't actually get a response back from the `client.run` method. You can see this if you run.

``` js
const campaign = await client.run("flight", "filter", {
      name: 'foo', // with an actual flight name
    });
console.log('campaign', campaign) // this doesn't happen / returns nothing
```

In this pr I've included checks further up for when querying for a `filter` so that it doesn't read the body twice this way the `filter` operation will return results. Because of these checks I've added the json conversion inside the status check so that errors are returned in the same way