### PR TITLE
[sc-66697] Replace node-fetch with nodejs fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adzerk/management-sdk",
-  "version": "1.0.0-beta.22",
+  "version": "1.0.0-beta.24",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@adzerk/management-sdk",
-      "version": "1.0.0-beta.22",
+      "version": "1.0.0-beta.24",
       "license": "Apache-2.0",
       "dependencies": {
         "@apidevtools/swagger-parser": "^10.0.0",
@@ -19,7 +19,6 @@
         "file-type": "^16.5.4",
         "form-data": "^4.0.0",
         "map-obj": "^4.3.0",
-        "node-fetch": "^3.3.2",
         "openapi-types": "^12.1.3",
         "strickland": "^2.2.0"
       },
@@ -29,7 +28,6 @@
         "@types/concat-stream": "^2.0.0",
         "@types/jest": "^26.0.8",
         "@types/node": "^22.5.4",
-        "@types/node-fetch": "^2.5.7",
         "babel-jest": "^29.7.0",
         "husky": "^8.0.3",
         "jest": "^29.7.0",
@@ -2779,30 +2777,6 @@
         "undici-types": "~6.19.2"
       }
     },
-    "node_modules/@types/node-fetch": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
-      "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^3.0.0"
-      }
-    },
-    "node_modules/@types/node-fetch/node_modules/form-data": {
-      "version": "3.0.1",
-      "resolved": "https://adzerkps.jfrog.io/artifactory/api/npm/npm/form-data/-/form-data-3.0.1.tgz",
-      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-      "dev": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -3587,15 +3561,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/date-fns": {
       "version": "2.30.0",
       "resolved": "https://adzerkps.jfrog.io/artifactory/api/npm/npm/date-fns/-/date-fns-2.30.0.tgz",
@@ -3909,29 +3874,6 @@
         "bser": "2.1.1"
       }
     },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
     "node_modules/file-type": {
       "version": "16.5.4",
       "resolved": "https://adzerkps.jfrog.io/artifactory/api/npm/npm/file-type/-/file-type-16.5.4.tgz",
@@ -4016,18 +3958,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "node_modules/fs.realpath": {
@@ -6182,43 +6112,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -7414,15 +7307,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/which": {
@@ -9488,29 +9372,6 @@
         "undici-types": "~6.19.2"
       }
     },
-    "@types/node-fetch": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.7.tgz",
-      "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*",
-        "form-data": "^3.0.0"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "3.0.1",
-          "resolved": "https://adzerkps.jfrog.io/artifactory/api/npm/npm/form-data/-/form-data-3.0.1.tgz",
-          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-          "dev": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
-        }
-      }
-    },
     "@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -10078,11 +9939,6 @@
         "which": "^2.0.1"
       }
     },
-    "data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="
-    },
     "date-fns": {
       "version": "2.30.0",
       "resolved": "https://adzerkps.jfrog.io/artifactory/api/npm/npm/date-fns/-/date-fns-2.30.0.tgz",
@@ -10300,15 +10156,6 @@
         "bser": "2.1.1"
       }
     },
-    "fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "requires": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      }
-    },
     "file-type": {
       "version": "16.5.4",
       "resolved": "https://adzerkps.jfrog.io/artifactory/api/npm/npm/file-type/-/file-type-16.5.4.tgz",
@@ -10375,14 +10222,6 @@
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
-      }
-    },
-    "formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "requires": {
-        "fetch-blob": "^3.1.2"
       }
     },
     "fs.realpath": {
@@ -11905,21 +11744,6 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
-    "node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
-    },
-    "node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "requires": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      }
-    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -12747,11 +12571,6 @@
       "requires": {
         "makeerror": "1.0.12"
       }
-    },
-    "web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adzerk/management-sdk",
-  "version": "1.0.0-beta.23",
+  "version": "1.0.0-beta.24",
   "description": "JavaScript SDK for Adzerk's Management API",
   "main": "lib/index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@types/concat-stream": "^2.0.0",
     "@types/jest": "^26.0.8",
     "@types/node": "^22.5.4",
-    "@types/node-fetch": "^2.5.7",
     "babel-jest": "^29.7.0",
     "husky": "^8.0.3",
     "jest": "^29.7.0",
@@ -66,7 +65,6 @@
     "file-type": "^16.5.4",
     "form-data": "^4.0.0",
     "map-obj": "^4.3.0",
-    "node-fetch": "^3.3.2",
     "openapi-types": "^12.1.3",
     "strickland": "^2.2.0"
   },

--- a/src/clientFactory.ts
+++ b/src/clientFactory.ts
@@ -1,6 +1,5 @@
 import { backOff } from 'exponential-backoff';
 import camelcase from 'camelcase';
-import fetch, { RequestInit, HeadersInit } from 'node-fetch';
 import http, { request } from 'http';
 import https from 'https';
 import { OpenAPI, OpenAPIV3 } from 'openapi-types';
@@ -217,7 +216,6 @@ const buildRequestArgs = async (
   client: Client | PromiseLike<Client>,
   headers: Headers,
   method: Method,
-  agent: http.Agent,
   obj: string,
   op: string,
   body: any,
@@ -225,7 +223,7 @@ const buildRequestArgs = async (
   logger: LoggerFunc,
   originalBody: any
 ) => {
-  let requestArgs: RequestInit = { headers, method, agent };
+  let requestArgs: RequestInit = { headers, method, keepalive: true, };
   let schema = operation.bodySchema;
 
   if (schema == undefined || !schema) {
@@ -351,10 +349,6 @@ export async function buildClient(opts: ClientFactoryOptions): Promise<Client> {
   let host = opts.host || 'api.adzerk.net';
   let port = opts.port || 443;
 
-  let agent = new (protocol === 'https' ? https : http).Agent({
-    keepAlive: true,
-  });
-
   return {
     async run(obj, op, body, qOpts) {
       let originalBody = body ? JSON.parse(JSON.stringify(body)) : null;
@@ -407,7 +401,6 @@ export async function buildClient(opts: ClientFactoryOptions): Promise<Client> {
         this,
         headers,
         operation.method,
-        agent,
         obj,
         op,
         body,
@@ -496,7 +489,7 @@ export async function buildClient(opts: ClientFactoryOptions): Promise<Client> {
 }
 
 let handleResponseStream = async <TAcc>({ body, callback, initialValue }: {
-  body: NodeJS.ReadableStream | null,
+  body: ReadableStream | null,
   callback: any,
   initialValue: TAcc
 }) => {
@@ -506,35 +499,30 @@ let handleResponseStream = async <TAcc>({ body, callback, initialValue }: {
     let accumulator = initialValue;
 
     if (body !== null) {
-      body.on('data', (d) => {
-        buffer = Buffer.concat([buffer, d]);
-        try {
-          buffer
-            .toString()
-            .trim()
-            .split('\n')
-            .forEach((l) => {
-              try {
-                let obj = convertKeysToCamelcase(JSON.parse(l));
-                accumulator = callback(accumulator, obj);
-                buffer = Buffer.alloc(0);
-              } catch {
-                buffer = Buffer.from(l);
-                return;
-              }
-            });
-        } catch (e) {
-          reject(e);
+      body.getReader().read().then(({ done, value }) => {
+        if (done) {
+          resolve(accumulator);
         }
-      });
 
-      body.on('end', () => resolve(accumulator));
+        buffer = Buffer.concat([buffer, value]);
 
-      body.on('close', () => resolve(accumulator));
-
-      body.on('finish', () => resolve(accumulator));
-
-      body.on('error', (e) => reject(e));
+        buffer
+          .toString()
+          .trim()
+          .split('\n')
+          .forEach((l) => {
+            try {
+              let obj = convertKeysToCamelcase(JSON.parse(l));
+              accumulator = callback(accumulator, obj);
+              buffer = Buffer.alloc(0);
+            } catch {
+              buffer = Buffer.from(l);
+              return;
+            }
+          });
+      }).catch(e => {
+        reject(e);
+      })
     }
     else {
       reject('Provided body was null.');

--- a/src/clientFactory.ts
+++ b/src/clientFactory.ts
@@ -496,12 +496,14 @@ let handleResponseStream = async <TAcc>({ body, callback, initialValue }: {
   let buffer = Buffer.alloc(0);
 
   return new Promise((resolve, reject) => {
-    let accumulator = initialValue;
-
     if (body !== null) {
-      body.getReader().read().then(({ done, value }) => {
+      let accumulator = initialValue;
+
+      const reader = body.getReader();
+
+      reader.read().then(function processChunk({ done, value }): any {
         if (done) {
-          resolve(accumulator);
+          return resolve(accumulator);
         }
 
         buffer = Buffer.concat([buffer, value]);
@@ -520,6 +522,8 @@ let handleResponseStream = async <TAcc>({ body, callback, initialValue }: {
               return;
             }
           });
+
+          return reader.read().then(processChunk);
       }).catch(e => {
         reject(e);
       })


### PR DESCRIPTION
Clients have reported that the SDK cannot be used in CommonJS projects. This is due to node-fetch@3 being an ESM only module. 

With Node v18
```
/adzerk-management-sdk-js/lib/clientFactory.js:56
var node_fetch_1 = __importDefault(require("node-fetch"));
                                   ^

Error [ERR_REQUIRE_ESM]: require() of ES Module /adzerk-management-sdk-js/node_modules/node-fetch/src/index.js from /adzerk-management-sdk-js/lib/clientFactory.js not supported.
Instead change the require of index.js in /adzerk-management-sdk-js/lib/clientFactory.js to a dynamic import() which is available in all CommonJS modules.
    at Object.<anonymous> (/adzerk-management-sdk-js/lib/clientFactory.js:56:36)
    at Object.<anonymous> (/adzerk-management-sdk-js/lib/index.js:114:23)
    at Object.<anonymous> (/js-sdk-client/index.js:1:14) {
  code: 'ERR_REQUIRE_ESM'
}

Node.js v18.18.2
```

With Node v20
```
/adzerk-management-sdk-js/lib/clientFactory.js:56
var node_fetch_1 = __importDefault(require("node-fetch"));
                                   ^

Error [ERR_REQUIRE_ESM]: require() of ES Module /adzerk-management-sdk-js/node_modules/node-fetch/src/index.js from /adzerk-management-sdk-js/lib/clientFactory.js not supported.
Instead change the require of index.js in /adzerk-management-sdk-js/lib/clientFactory.js to a dynamic import() which is available in all CommonJS modules.
    at Object.<anonymous> (/adzerk-management-sdk-js/lib/clientFactory.js:56:36) {
  code: 'ERR_REQUIRE_ESM'
}

Node.js v20.16.0
```

There are workarounds suggested by the maintainers of [node-fetch](https://www.npmjs.com/package/node-fetch#commonjs) for use with CommonJS, however our use is minimal, therefore we can replace it with NodeJS's [fetch](https://nodejs.org/dist/v18.20.5/docs/api/globals.html#fetch) which was made GA in v18. 

Tested using https://github.com/adzerk/adzerk-management-sdk-integration-tests pointing to a local copy of the SDK.