### PR TITLE
[sc-67340] Reintroduce node-fetch v2 instead of v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,15 +19,18 @@
         "file-type": "^16.5.4",
         "form-data": "^4.0.0",
         "map-obj": "^4.3.0",
+        "node-fetch": "^2.7.0",
         "openapi-types": "^12.1.3",
         "strickland": "^2.2.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.25.4",
         "@types/array.prototype.flatmap": "^1.2.2",
+        "@types/camelcase": "^5.2.4",
         "@types/concat-stream": "^2.0.0",
         "@types/jest": "^26.0.8",
         "@types/node": "^22.5.4",
+        "@types/node-fetch": "^2.6.12",
         "babel-jest": "^29.7.0",
         "husky": "^8.0.3",
         "jest": "^29.7.0",
@@ -2705,6 +2708,17 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/camelcase": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@types/camelcase/-/camelcase-5.2.4.tgz",
+      "integrity": "sha512-JWwptVdUMImf+3HNozv0FFyxELml7WQviImEopqA+nEfAT8oMDB3GoVUdkSdxhKxb3wyYeD6uykaQtoDKx3Sbg==",
+      "deprecated": "This is a stub types definition. camelcase provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "*"
+      }
+    },
     "node_modules/@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -2775,6 +2789,17 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.0"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -6112,6 +6137,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -7024,6 +7069,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-jest": {
       "version": "29.2.5",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.2.5.tgz",
@@ -7307,6 +7358,22 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -9305,6 +9372,15 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "@types/camelcase": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@types/camelcase/-/camelcase-5.2.4.tgz",
+      "integrity": "sha512-JWwptVdUMImf+3HNozv0FFyxELml7WQviImEopqA+nEfAT8oMDB3GoVUdkSdxhKxb3wyYeD6uykaQtoDKx3Sbg==",
+      "dev": true,
+      "requires": {
+        "camelcase": "*"
+      }
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -9370,6 +9446,16 @@
       "dev": true,
       "requires": {
         "undici-types": "~6.19.2"
+      }
+    },
+    "@types/node-fetch": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^4.0.0"
       }
     },
     "@types/stack-utils": {
@@ -11744,6 +11830,14 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -12403,6 +12497,11 @@
         "ieee754": "^1.2.1"
       }
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "ts-jest": {
       "version": "29.2.5",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.2.5.tgz",
@@ -12570,6 +12669,20 @@
       "dev": true,
       "requires": {
         "makeerror": "1.0.12"
+      }
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -28,9 +28,11 @@
   "devDependencies": {
     "@babel/preset-env": "^7.25.4",
     "@types/array.prototype.flatmap": "^1.2.2",
+    "@types/camelcase": "^5.2.4",
     "@types/concat-stream": "^2.0.0",
     "@types/jest": "^26.0.8",
     "@types/node": "^22.5.4",
+    "@types/node-fetch": "^2.6.12",
     "babel-jest": "^29.7.0",
     "husky": "^8.0.3",
     "jest": "^29.7.0",
@@ -65,6 +67,7 @@
     "file-type": "^16.5.4",
     "form-data": "^4.0.0",
     "map-obj": "^4.3.0",
+    "node-fetch": "^2.7.0",
     "openapi-types": "^12.1.3",
     "strickland": "^2.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adzerk/management-sdk",
-  "version": "1.0.0-beta.24",
+  "version": "1.0.0-beta.25",
   "description": "JavaScript SDK for Adzerk's Management API",
   "main": "lib/index.js",
   "engines": {
@@ -28,7 +28,6 @@
   "devDependencies": {
     "@babel/preset-env": "^7.25.4",
     "@types/array.prototype.flatmap": "^1.2.2",
-    "@types/camelcase": "^5.2.4",
     "@types/concat-stream": "^2.0.0",
     "@types/jest": "^26.0.8",
     "@types/node": "^22.5.4",

--- a/src/clientFactory.ts
+++ b/src/clientFactory.ts
@@ -5,6 +5,7 @@ import https from 'https';
 import { OpenAPI, OpenAPIV3 } from 'openapi-types';
 import validate from 'strickland';
 import { URL } from 'url';
+import fetch, { RequestInit } from 'node-fetch';
 
 import { LoggerFunc } from '.';
 import { parseSpecifications, SecuritySchema, Operation, Method } from './specParser';
@@ -37,7 +38,7 @@ type Processor = (entity: { [key: string]: any }) => { [key: string]: any };
 
 /**
  * Generate cap amount processor with given field names.
- * 
+ *
  * @param param0 input parameters.
  * @returns Cap amount processor.
  */
@@ -49,18 +50,18 @@ const generateCapAmountProcessor =
     capAmountName: string;
     capAmountDecimalName: string;
   }) =>
-    (entity: { [key: string]: any }) => {
-      let capAmount = entity[capAmountName];
-      let capAmountDecimal = entity[capAmountDecimalName];
-      if (capAmount && !capAmountDecimal) {
-        return { ...entity, [capAmountDecimalName]: capAmount };
-      } else if (!capAmount && capAmountDecimal) {
-        // CapAmount must be equal to CapAmountDecimal rounded up.
-        return { ...entity, [capAmountName]: Math.ceil(capAmountDecimal) };
-      } else {
-        return entity;
-      }
-    };
+  (entity: { [key: string]: any }) => {
+    let capAmount = entity[capAmountName];
+    let capAmountDecimal = entity[capAmountDecimalName];
+    if (capAmount && !capAmountDecimal) {
+      return { ...entity, [capAmountDecimalName]: capAmount };
+    } else if (!capAmount && capAmountDecimal) {
+      // CapAmount must be equal to CapAmountDecimal rounded up.
+      return { ...entity, [capAmountName]: Math.ceil(capAmountDecimal) };
+    } else {
+      return entity;
+    }
+  };
 
 /**
  * Map of preprocessors for any endpoints that require it.
@@ -216,6 +217,7 @@ const buildRequestArgs = async (
   client: Client | PromiseLike<Client>,
   headers: Headers,
   method: Method,
+  agent: http.Agent,
   obj: string,
   op: string,
   body: any,
@@ -223,7 +225,7 @@ const buildRequestArgs = async (
   logger: LoggerFunc,
   originalBody: any
 ) => {
-  let requestArgs: RequestInit = { headers, method, keepalive: true, };
+  let requestArgs: RequestInit = { headers, method, agent };
   let schema = operation.bodySchema;
 
   if (schema == undefined || !schema) {
@@ -273,15 +275,15 @@ const buildRequestArgs = async (
   let buildIdOnlySchema = (isCapitalized: boolean): OpenAPIV3.NonArraySchemaObject =>
     isCapitalized
       ? {
-        type: 'object',
-        required: ['Id'],
-        properties: { Id: { type: 'integer', format: 'int32' } },
-      }
+          type: 'object',
+          required: ['Id'],
+          properties: { Id: { type: 'integer', format: 'int32' } },
+        }
       : {
-        type: 'object',
-        required: ['id'],
-        properties: { id: { type: 'integer', format: 'int32' } },
-      };
+          type: 'object',
+          required: ['id'],
+          properties: { id: { type: 'integer', format: 'int32' } },
+        };
 
   let serializer = bodySerializerFactory(contentType);
   let propertyNames = Object.keys(schema[contentType].properties || {});
@@ -349,6 +351,10 @@ export async function buildClient(opts: ClientFactoryOptions): Promise<Client> {
   let host = opts.host || 'api.adzerk.net';
   let port = opts.port || 443;
 
+  let agent = new (protocol === 'https' ? https : http).Agent({
+    keepAlive: true,
+  });
+
   return {
     async run(obj, op, body, qOpts) {
       let originalBody = body ? JSON.parse(JSON.stringify(body)) : null;
@@ -401,6 +407,7 @@ export async function buildClient(opts: ClientFactoryOptions): Promise<Client> {
         this,
         headers,
         operation.method,
+        agent,
         obj,
         op,
         body,
@@ -474,7 +481,7 @@ export async function buildClient(opts: ClientFactoryOptions): Promise<Client> {
       let result = await handleResponseStream({
         body: r.body,
         callback: callback,
-        initialValue: (qOpts && qOpts.initialValue) || []
+        initialValue: (qOpts && qOpts.initialValue) || [],
       });
 
       let converted = convertKeysToCamelcase(result);
@@ -488,47 +495,51 @@ export async function buildClient(opts: ClientFactoryOptions): Promise<Client> {
   };
 }
 
-let handleResponseStream = async <TAcc>({ body, callback, initialValue }: {
-  body: ReadableStream | null,
-  callback: any,
-  initialValue: TAcc
+let handleResponseStream = async <TAcc>({
+  body,
+  callback,
+  initialValue,
+}: {
+  body: NodeJS.ReadableStream | null;
+  callback: any;
+  initialValue: TAcc;
 }) => {
   let buffer = Buffer.alloc(0);
 
   return new Promise((resolve, reject) => {
+    let accumulator = initialValue;
+
     if (body !== null) {
-      let accumulator = initialValue;
-
-      const reader = body.getReader();
-
-      reader.read().then(function processChunk({ done, value }): any {
-        if (done) {
-          return resolve(accumulator);
+      body.on('data', (d) => {
+        buffer = Buffer.concat([buffer, d]);
+        try {
+          buffer
+            .toString()
+            .trim()
+            .split('\n')
+            .forEach((l) => {
+              try {
+                let obj = convertKeysToCamelcase(JSON.parse(l));
+                accumulator = callback(accumulator, obj);
+                buffer = Buffer.alloc(0);
+              } catch {
+                buffer = Buffer.from(l);
+                return;
+              }
+            });
+        } catch (e) {
+          reject(e);
         }
+      });
 
-        buffer = Buffer.concat([buffer, value]);
+      body.on('end', () => resolve(accumulator));
 
-        buffer
-          .toString()
-          .trim()
-          .split('\n')
-          .forEach((l) => {
-            try {
-              let obj = convertKeysToCamelcase(JSON.parse(l));
-              accumulator = callback(accumulator, obj);
-              buffer = Buffer.alloc(0);
-            } catch {
-              buffer = Buffer.from(l);
-              return;
-            }
-          });
+      body.on('close', () => resolve(accumulator));
 
-          return reader.read().then(processChunk);
-      }).catch(e => {
-        reject(e);
-      })
-    }
-    else {
+      body.on('finish', () => resolve(accumulator));
+
+      body.on('error', (e) => reject(e));
+    } else {
       reject('Provided body was null.');
     }
   });


### PR DESCRIPTION
`uploadImage` was broken when using NodeJS native `fetch`. The way form data is handled is dependent on node-fetch and form-data packages. This change reintroduces node-fetch, but a downgraded version (2) to address the issue described in https://github.com/adzerk/adzerk-management-sdk-js/pull/145.