### PR TITLE
[PE-1145] Add GitHub CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# This file defines who is responsible for different parts of the codebase
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# These owners will be the default owners for everything in the repo
+* @adzerk/management


### PR DESCRIPTION
Add a GitHub CODEOWNERS file to define code ownership for this repository.

### Does this change relate to existing features and pull requests?

Part of [PE-1145] -- Adding a GitHub CODEOWNERS file to all Kevel GitHub repositories

[PE-1145]: https://kevel-team.atlassian.net/browse/PE-1145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ