### PR TITLE
Migrate @adzerk/management-sdk npm publish to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,27 +4,24 @@ on:
   release:
     types: [published]
 
-env:
-  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-  NPM_REGISTRY: registry.npmjs.org
-  NPM_SECRET: ${{ secrets.NPM_TOKEN }}
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Setup NodeJS
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: 24
         registry-url: https://registry.npmjs.org
     - name: Install Dependencies
       run: npm install
     - name: Build SDK
       run: npm run build
-    - name: Publish to NPM
-      run: npm publish
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - name: Publish to NPM (Trusted Publishing / OIDC)
+      run: npm publish --provenance --access public


### PR DESCRIPTION
Drops the `NPM_TOKEN` secret in favor of npm Trusted Publishing (OIDC) + provenance. Also bumps `checkout`/`setup-node` to v4 and Node 20->24 (Node 20 ships npm 10.x, below the 11.5.1 required for OIDC).

Requires the npm trusted-publisher config for `@adzerk/management-sdk` (repo `adzerk-management-sdk-js`, workflow `publish.yml`). The `NPM_TOKEN` secret should be deleted after a green release.

Part of PE-1733.